### PR TITLE
sem_pcyc setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ PyTorch implementation of our SEM-PCYC model for zero-shot sketch-based image re
 |성공 |성공 |18.04 | 1080 Ti   |470.57.02|11.4   |4.7.12|3.6.13|1.4.0  py3.6_cuda9.2.148_cuddn7.6.3_0|0.5.0| 
 |성공 |성공 |18.04 | 2070 SUPER|470.57.02|11.4   |4.7.12|3.6.13|1.4.0 py3.6_cuda9.2.148_cuddn7.6.3_0|0.5.0|
 |성공 |성공 |20.04 | 1660 SUPER|470.57.02|11.4   |4.7.12|3.6.10|1.7.1 py3.6_cuda9.2.148_cuddn7.6.3_0|0.8.2|
-
+|성공 |성공 |18.04 | A100 (NIPA 서버)|470.103.01|11.4   |4.10.3|3.7.10|1.7.1+cu110|0.8.2+cu110|
 
 ## Prerequisites
 
@@ -61,6 +61,17 @@ torchvision               0.2.2.post3              pypi_0    pypi
 - scikit-learn
 - google ( 데이터를 온라인 다운로드 받을 경우 사용, 로컬에 저장해서 사용할때는 필요 없음 )
 - tqdm
+
+```bash
+train을 위한 최소한의 라이브러리 설치
+conda create -n sbir_pytorch_p37 python=3.7.10
+conda install pytorch==1.7.1 torchvision==0.8.2 torchaudio==0.7.2 cudatoolkit=11.0 -c pytorch
+conda install -c anaconda joblib=0.12.1
+conda install -c anaconda scikit-learn
+conda install numpy=1.14.0
+conda install -c conda-forge tensorboardx
+```
+
 
 ```bash
 pip install --upgrade google-api-python-client

--- a/config.ini
+++ b/config.ini
@@ -2,7 +2,7 @@
 ; Comments start with ';', as in config.ini
 ; Update the paths for different workstations and servers
 
-[mwmw7-desktop]
+[nipa2022-49750]
 ;path_dataset = /mnt/workspace/ml_data_m2/sem_pcyc
-path_dataset = /ml_data/sem_pcyc/dataset
-path_aux = /ml_data/sem_pcyc/aux
+path_dataset = /home/ubuntu/sem_pcyc/data/sem_pcyc/dataset
+path_aux = /home/ubuntu/sem_pcyc/data/sem_pcyc/aux

--- a/src/train.py
+++ b/src/train.py
@@ -388,4 +388,5 @@ def train(train_loader, sem_pcyc_model, epoch, args):
 
 
 if __name__ == '__main__':
+    torch.autograd.set_detect_anomaly(True)
     main()


### PR DESCRIPTION
# 이슈
sem_pcyc train 시 backward()가 수행이 안되고 runtime error가 발생하는이슈

# 이슈 설명
여러 loss가 존재할 때, 앞선 loss가 계산이 된 이후, inplce = True 상태로 인해 gradient loss(경사값)를 저장하고 있는 파라미터가 갱신이 되고, 이전 gradient loss를 사용해서 backward()를 진행하여 발생하는 오류

# 해결
optimizer에 사용된 ReLU, LeakyReLU 옵션에서 inplace = False로 변경하였고, 따로 떨어져 있던 auto encoder, generator, discriminator 세 가지의 optimizer step을 loss값을 모두 구하고 난 후에 처리하도록 코드 수정

generator loss와 discriminator loss값이 epoch가 진행됨에 따라 감소하는 것을 확인하였고, 모델이 저장되는 것도 확인하였지만, 제대로 학습되는지 걱정돼서 교수님에게 다시 메일을 보낸 상황