### PR TITLE
sem pcyc 3d thumbnail train

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ PyTorch implementation of our SEM-PCYC model for zero-shot sketch-based image re
 |성공 |성공 |18.04 | 1080 Ti   |470.57.02|11.4   |4.7.12|3.6.13|1.4.0  py3.6_cuda9.2.148_cuddn7.6.3_0|0.5.0| 
 |성공 |성공 |18.04 | 2070 SUPER|470.57.02|11.4   |4.7.12|3.6.13|1.4.0 py3.6_cuda9.2.148_cuddn7.6.3_0|0.5.0|
 |성공 |성공 |20.04 | 1660 SUPER|470.57.02|11.4   |4.7.12|3.6.10|1.7.1 py3.6_cuda9.2.148_cuddn7.6.3_0|0.8.2|
-
+|성공 |성공 |18.04 | A100 (NIPA 서버)|470.103.01|11.4   |4.10.3|3.7.10|1.7.1+cu110|0.8.2+cu110|
 
 ## Prerequisites
 
@@ -61,6 +61,17 @@ torchvision               0.2.2.post3              pypi_0    pypi
 - scikit-learn
 - google ( 데이터를 온라인 다운로드 받을 경우 사용, 로컬에 저장해서 사용할때는 필요 없음 )
 - tqdm
+
+```bash
+train을 위한 최소한의 라이브러리 설치
+conda create -n sbir_pytorch_p37 python=3.7.10
+conda install pytorch==1.7.1 torchvision==0.8.2 torchaudio==0.7.2 cudatoolkit=11.0 -c pytorch
+conda install -c anaconda joblib=0.12.1
+conda install -c anaconda scikit-learn
+conda install numpy=1.14.0
+conda install -c conda-forge tensorboardx
+```
+
 
 ```bash
 pip install --upgrade google-api-python-client

--- a/config.ini
+++ b/config.ini
@@ -2,7 +2,7 @@
 ; Comments start with ';', as in config.ini
 ; Update the paths for different workstations and servers
 
-[mwmw7-desktop]
+[nipa2022-49750]
 ;path_dataset = /mnt/workspace/ml_data_m2/sem_pcyc
-path_dataset = /ml_data/sem_pcyc/dataset
-path_aux = /ml_data/sem_pcyc/aux
+path_dataset = /home/ubuntu/sem_pcyc/data/sem_pcyc/dataset
+path_aux = /home/ubuntu/sem_pcyc/data/sem_pcyc/aux

--- a/src/data.py
+++ b/src/data.py
@@ -24,9 +24,16 @@ class DataGeneratorPaired(data.Dataset):
         self.transforms_image = transforms_image
 
     def __getitem__(self, item):
+        # 스케치 데이터가 RGBA 일 경우 Alpha값을 빼고 RGB로 invert
         image = Image.open(os.path.join(self.root, self.sketch_dir, self.sketch_sd, self.fls_sk[item]))
-        sk = ImageOps.invert(image.convert('RGB')).\
-            convert(mode='RGB')
+
+        if image.mode == 'RGBA':
+            r, g, b, a = image.split()
+            rgb_image = Image.merge('RGB', (r, g, b))
+            sk = ImageOps.invert(rgb_image)
+        else:
+            sk = ImageOps.invert(image.convert('RGB')). \
+                convert(mode='RGB')
         im = Image.open(os.path.join(self.root, self.photo_dir, self.photo_sd, self.fls_im[item])).convert(mode='RGB')
         cls = self.clss[item]
         if self.transforms_image is not None:
@@ -58,8 +65,20 @@ class DataGeneratorSketch(data.Dataset):
         self.transforms = transforms
 
     def __getitem__(self, item):
-        sk = ImageOps.invert(Image.open(os.path.join(self.root, self.sketch_dir, self.sketch_sd, self.fls_sk[item]))).\
-            convert(mode='RGB')
+        # sk = ImageOps.invert(Image.open(os.path.join(self.root, self.sketch_dir, self.sketch_sd, self.fls_sk[item]))).\
+        #     convert(mode='RGB')
+
+        # 스케치 데이터가 RGBA 일 경우 Alpha값을 빼고 RGB로 invert
+        image = Image.open(os.path.join(self.root, self.sketch_dir, self.sketch_sd, self.fls_sk[item]))
+
+        if image.mode == 'RGBA':
+            r, g, b, a = image.split()
+            rgb_image = Image.merge('RGB', (r, g, b))
+            sk = ImageOps.invert(rgb_image)
+        else:
+            sk = ImageOps.invert(image.convert('RGB')). \
+                convert(mode='RGB')
+
         cls_sk = self.clss_sk[item]
         if self.transforms is not None:
             sk = self.transforms(sk)

--- a/src/mk_image_emd_npy.py
+++ b/src/mk_image_emd_npy.py
@@ -9,11 +9,16 @@ import torch
 from torch.utils.data import DataLoader
 
 class MakeNPY():
+    """
+    새롭게 추가된 이미지의 embedding값을 추출하는 역할을 한다.
+    이를 통해 만들어진 acc_im_em.npy 파일은 .mar을 생성할 때, extra_files 옵션으로 들어간다.
+    input으로 들어오는 한 장의 sketch embedding 값과 이미지들의 embedding 값의 거리값을 비교할 때 사용된다.
+    """
     def __init__(self):
-        # self.path_dataset = '/home/ubuntu/sem_pcyc/dataset'
-        # self.path_aux = '/home/ubuntu/sem_pcyc/aux'
-        self.path_dataset = '/home/model-server/sem_pcyc/dataset'
-        self.path_aux = '/home/model-server/sem_pcyc/aux'
+        self.path_dataset = '/home/ubuntu/sem_pcyc/data/sem_pcyc/dataset'
+        self.path_aux = '/home/ubuntu/sem_pcyc/data/sem_pcyc/aux'
+        # self.path_dataset = '/home/model-server/sem_pcyc/dataset'
+        # self.path_aux = '/home/model-server/sem_pcyc/aux'
         self.dataset = 'intersection'
         self.root_path  = os.path.join(self.path_dataset, self.dataset)
         self.photo_dir = 'images'
@@ -201,9 +206,10 @@ class MakeNPY():
 
 
         sem_pcyc_model = SEM_PCYC(params_model)
-        path_pth ="/home/model-server/sem_pcyc/aux/CheckPoints/intersection/new_plus_words/64/model_best.pth"
+        # path_pth ="/home/model-server/sem_pcyc/aux/CheckPoints/intersection/new_plus_words/64/model_best.pth"
+        path_pth = "/home/ubuntu/sem_pcyc/data/sem_pcyc/aux/CheckPoints/intersection/new_plus_words/64/model_best.pth"
         device = torch.device("cuda")
-        checkpoint = torch.load(path_pth,map_location="cuda:0")
+        checkpoint = torch.load(path_pth, map_location="cuda:0")
         sem_pcyc_model.load_state_dict(checkpoint['state_dict'])
         sem_pcyc_model.to(device)
         sem_pcyc_model.eval()
@@ -216,7 +222,8 @@ def main() :
     print('size acc_im_em : {}'.format(len(acc_im_em)))
     print("\n")
     print("--------------START Saving--------------")
-    np.save("/home/model-server/npy/acc_im_em.npy", acc_im_em)
+    # np.save("/home/model-server/npy/acc_im_em.npy", acc_im_em)
+    np.save("/home/ubuntu/sem_pcyc/data/sem_pcyc/npy", acc_im_em)
     print("--------------END Saving--------------")
 
 if __name__ == "__main__":

--- a/src/newclass_word2vec.py
+++ b/src/newclass_word2vec.py
@@ -8,17 +8,24 @@ import numpy as np
 import utils
 
 # root_path = "/home/ubuntu/sem_pcyc/dataset/intersection/images"
-root_path = "/home/model-server/sem_pcyc/dataset/intersection/images"
+# root_path = "/home/model-server/sem_pcyc/dataset/intersection/images"
+root_path = "/home/ubuntu/sem_pcyc/data/sem_pcyc/dataset/intersection/images"
 
 def create_wordemb(root_path, type='word2vec-google-news-300'):
+    """
+    이미지의 클래스가 추가되었을 경우, word to vector를 통해 새로운 vector 값을 만들어주는 함수
+    """
     clss = glob.glob(os.path.join(root_path, '*'))
     clss = [c.split('/')[-1] for c in clss if os.path.isdir(c)]
     available_type = ['word2vec-google-news-300', 'fasttext-wiki-news-subwords-300', 'glove-wiki-gigaword-300']
     if type not in available_type:
         print("Type specified does not exist.")
         exit()
+    # model = gensim.models.KeyedVectors.load_word2vec_format(
+    #     '/home/model-server/GoogleNews-vectors-negative300.bin', binary=True).wv
+
     model = gensim.models.KeyedVectors.load_word2vec_format(
-        '/home/model-server/GoogleNews-vectors-negative300.bin', binary=True).wv        # 구글워드투벡 옮기기!!!!!!!!!
+        '/home/ubuntu/sem_pcyc/GoogleNews-vectors-negative300.bin', binary=True).wv
 
     lv = len(model['airplane'])  # for knowing the length of vector
 
@@ -48,7 +55,9 @@ plus_word = {}
 plus_word = create_wordemb(root_path)
 
 # 생성한 dict를 npy로 만들기
-np.save('/home/model-server/sem_pcyc/aux/Semantic/intersection/new_plus_words.npy', plus_word)
+# np.save('/home/model-server/sem_pcyc/aux/Semantic/intersection/new_plus_words.npy', plus_word)
+print('making npy.... ')
+np.save('/home/ubuntu/sem_pcyc/data/sem_pcyc/aux/Semantic/intersection/new_plus_words.npy', plus_word)
 print('npy create!')
 
 '''

--- a/src/train.py
+++ b/src/train.py
@@ -327,6 +327,9 @@ def main():
 
 
 def train(train_loader, sem_pcyc_model, epoch, args):
+    """
+    sem_pcyc 학습시키기
+    """
 
     # Switch to train mode
     sem_pcyc_model.train()

--- a/src/train.py
+++ b/src/train.py
@@ -388,4 +388,5 @@ def train(train_loader, sem_pcyc_model, epoch, args):
 
 
 if __name__ == '__main__':
+    torch.autograd.set_detect_anomaly(True)
     main()

--- a/ts/torch_handler/sem_pcyc_handler.py
+++ b/ts/torch_handler/sem_pcyc_handler.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 class ModelHandler(BaseHandler):
     """
-    A custom model handler implementation.
+    sem_pcyc 모델의 .mar 파일을 생성하는 모델 핸들러
     """
 
     def __init__(self):
@@ -52,12 +52,16 @@ class ModelHandler(BaseHandler):
         self.acc_im_em_npy_saved = None
         self.max_prediction_size = 30
         # 모델 등록용
-        self.npy_path = '/home/model-server/npy'
+        # self.npy_path = '/home/model-server/npy'
+        self.npy_path = '/home/ubuntu/sem_pcyc/data/sem_pcyc/npy'
         npy_full_path = os.path.join(self.npy_path, "acc_im_em.npy")
         if os.path.isfile(npy_full_path):
             self.acc_im_em = self.np_load(npy_full_path)
 
     def np_load(self, npy_path):
+        """
+        mk_image_emd_npy를 통해 생성한 acc_im_em.npy 파일을 load하는 함수
+        """
         images_emd = np.load(npy_path)
         print('success load acc_im_em.npy~!!!!!')
         self.acc_im_em_npy_saved = True
@@ -169,8 +173,10 @@ class ModelHandler(BaseHandler):
         sem_dim = 0
 
         # 모델 등록용
-        path_dataset = '/home/model-server/sem_pcyc/dataset'
-        path_aux = '/home/model-server/sem_pcyc/aux'
+        # path_dataset = '/home/model-server/sem_pcyc/dataset'
+        # path_aux = '/home/model-server/sem_pcyc/aux'
+        path_dataset = '/home/ubuntu/sem_pcyc/data/sem_pcyc/dataset'
+        path_aux = '/home/ubuntu/sem_pcyc/data/sem_pcyc/aux'
         self.dataset = dataset = 'intersection'
         semantic_models = ['new_plus_words']
         files_semantic_labels = []

--- a/ts/torch_handler/sem_pcyc_handler.py
+++ b/ts/torch_handler/sem_pcyc_handler.py
@@ -40,7 +40,7 @@ class ModelHandler(BaseHandler):
         self.transform_sketch = None
         self.dataset = None
         self.num_workers = 4
-        self.batch_size = 512
+        self.batch_size = 8
         self.test_loader_image = None
         self.root_path = None
         self.photo_dir = None
@@ -52,8 +52,8 @@ class ModelHandler(BaseHandler):
         self.acc_im_em_npy_saved = None
         self.max_prediction_size = 30
         # 모델 등록용
-        # self.npy_path = '/home/model-server/npy'
-        self.npy_path = '/home/ubuntu/sem_pcyc/data/sem_pcyc/npy'
+        self.npy_path = '/home/model-server/npy'
+        # self.npy_path = '/home/ubuntu/sem_pcyc/data/sem_pcyc/npy'
         npy_full_path = os.path.join(self.npy_path, "acc_im_em.npy")
         if os.path.isfile(npy_full_path):
             self.acc_im_em = self.np_load(npy_full_path)
@@ -173,10 +173,10 @@ class ModelHandler(BaseHandler):
         sem_dim = 0
 
         # 모델 등록용
-        # path_dataset = '/home/model-server/sem_pcyc/dataset'
-        # path_aux = '/home/model-server/sem_pcyc/aux'
-        path_dataset = '/home/ubuntu/sem_pcyc/data/sem_pcyc/dataset'
-        path_aux = '/home/ubuntu/sem_pcyc/data/sem_pcyc/aux'
+        path_dataset = '/home/model-server/sem_pcyc/dataset'
+        path_aux = '/home/model-server/sem_pcyc/aux'
+        # path_dataset = '/home/ubuntu/sem_pcyc/data/sem_pcyc/dataset'
+        # path_aux = '/home/ubuntu/sem_pcyc/data/sem_pcyc/aux'
         self.dataset = dataset = 'intersection'
         semantic_models = ['new_plus_words']
         files_semantic_labels = []
@@ -499,8 +499,8 @@ class ModelHandler(BaseHandler):
 
         # all the unique classes
         classes = np.unique(clss_im)
-        print("mar 생성 이미지 클래스", classes)
-        print("mar 생성 이미지 클래스의 개수", len(classes))
+        print("classes", classes)
+        print("number of classes", len(classes))
 
         # divide the classes, done according to the "Zero-Shot Sketch-Image Hashing" paper
         np.random.seed(0)


### PR DESCRIPTION
# 이슈
3d Thumbnail이 잘 출력되도록 sem-pcyc train 및 mar 생성

# 이슈 설명 
1. 옵티마이저 relu와 leakyrelu 부분에서 inplace=true 옵션을 주고, zero_grad()부분을 backward 메소드가 시작될 때 호출되도록 이동해서 중간에 재사용된 모델의 gradient가 0이 되지 않도록 수정 (저번에 올렸던 이슈 참고해서 수정)

2. 3d data set의 스케치 데이터셋을 위해 선화 필터를 활용하였는데, 선화를 적용할 경우 이미지가 RGB에서 RGBA로 변경되어 각 모드에 따라 RGB로 변환할 수 있도록 코드 수정

3. acc_im_em.npy를 생성할 때, _get_coarse_grained_samples 메소드에서 추가된 클래스를 인식하지 못하는 이슈가 있어서  리소스 이미지의 확장자가 base64인 파일들만 인식되도록 수정

4. 각 메소드마다 주석 추가

5. sem_pcyc handler.py에서 메모리 이슈로 인해 batch_size를 8로 낮추고 ec2 인스턴스 경로에 맞게 경로 수정



 



